### PR TITLE
Cookie Banner

### DIFF
--- a/src/components/cookie-banner.js
+++ b/src/components/cookie-banner.js
@@ -1,0 +1,72 @@
+import React from "react";
+import Link from "gatsby-link";
+import styled from "styled-components";
+import colors from "../constants/colors";
+
+const CloseIcon = () =>
+  <svg
+    fill={colors.white}
+    height="24"
+    viewBox="0 0 24 24"
+    width="24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z" />
+    <path d="M0 0h24v24H0z" fill="none" />
+  </svg>;
+
+const Banner = styled.div`
+  display: flex;
+  align-items: center;
+  color: ${colors.white};
+  > p {
+    flex: 1;
+  }
+`;
+
+const BannerLink = styled(Link)`
+  color: ${colors.white};
+
+  :visited {
+    color: ${colors.white5};
+  }
+`;
+
+const CloseButton = styled.button`
+  background: none;
+  border: none;
+  :focus {
+    outline: none;
+  }
+`;
+
+class CookieBanner extends React.Component {
+  state = {
+    hideCookieBanner: localStorage.getItem("hideCookieBanner")
+  };
+  hideCookieBanner = () => {
+    localStorage.setItem("hideCookieBanner", true);
+    this.setState({
+      hideCookieBanner: true
+    });
+  };
+  render() {
+    console.log(this.state);
+    return this.state.hideCookieBanner
+      ? null
+      : <Banner>
+          <p>
+            SoftBricks möchte Ihnen den bestmöglichen Service bieten. Dazu
+            speichern wir Informationen über Ihren Besuch in sogenannten
+            Cookies. Wenn Sie auf der Seite weitersurfsen, stimmen Sie der
+            Cookie-Nutzung zu. Detaillierte Informationen über den Einsatz von
+            Cookies auf dieser Webseite erhälten Sie unter “<BannerLink to="datenschutz">Datenschutz</BannerLink>”.
+          </p>
+          <CloseButton onClick={this.hideCookieBanner}>
+            <CloseIcon />
+          </CloseButton>
+        </Banner>;
+  }
+}
+
+export default CookieBanner;

--- a/src/components/cookie-banner.js
+++ b/src/components/cookie-banner.js
@@ -42,8 +42,13 @@ const CloseButton = styled.button`
 
 class CookieBanner extends React.Component {
   state = {
-    hideCookieBanner: localStorage.getItem("hideCookieBanner")
+    hideCookieBanner: true
   };
+  componentDidMount() {
+    this.setState({
+      hideCookieBanner: localStorage.getItem("hideCookieBanner")
+    });
+  }
   hideCookieBanner = () => {
     localStorage.setItem("hideCookieBanner", true);
     this.setState({

--- a/src/components/cookie-banner.js
+++ b/src/components/cookie-banner.js
@@ -61,11 +61,10 @@ class CookieBanner extends React.Component {
       ? null
       : <Banner>
           <p>
-            SoftBricks möchte Ihnen den bestmöglichen Service bieten. Dazu
-            speichern wir Informationen über Ihren Besuch in sogenannten
-            Cookies. Wenn Sie auf der Seite weitersurfsen, stimmen Sie der
-            Cookie-Nutzung zu. Detaillierte Informationen über den Einsatz von
-            Cookies auf dieser Webseite erhälten Sie unter “<BannerLink to="datenschutz">Datenschutz</BannerLink>”.
+            Um unsere Webseite für Sie optimal zu gestalten und fortlaufend
+            verbessern zu können, verwenden wir Cookies. Durch die weitere
+            Nutzung der Webseite stimmen Sie der Verwendung von Cookies zu.
+            Weitere Informationen zu Cookies erhalten Sie in unserer <BannerLink to="datenschutz">Datenschutzerklärung</BannerLink>
           </p>
           <CloseButton onClick={this.hideCookieBanner}>
             <CloseIcon />

--- a/src/constants/colors.js
+++ b/src/constants/colors.js
@@ -1,6 +1,7 @@
 const colors = {
   orange: "#ef891c",
   black: "#151517",
+  gray: "#2e2e2f",
   white: "hsl(20, 7%, 91%)",
   white5: "hsl(20, 7%, 50%)"
 };

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -6,6 +6,7 @@ import styled from "styled-components";
 import favicon from "../../public/static/favicon.ico";
 import Inline from "../components/inline";
 import Stack from "../components/stack";
+import CookieBanner from "../components/cookie-banner";
 import SoftBricksLogo from "../components/softbricks-logo";
 import ResponsiveContainer from "../components/responsive-container";
 import Toolbar from "../components/toolbar";
@@ -22,10 +23,22 @@ const HorizontalBar = styled.div`
   z-index: 1;
 `;
 
+const BannerBar = styled(HorizontalBar)`
+  background-color: ${colors.gray};
+  position: static;
+`;
+
 const LogoLink = styled(Link)`
   color: white;
   text-decoration: none;
 `;
+
+const CookieHeader = () =>
+  <BannerBar>
+    <ResponsiveContainer>
+      <CookieBanner />
+    </ResponsiveContainer>
+  </BannerBar>;
 
 const Header = () =>
   <HorizontalBar>
@@ -54,6 +67,7 @@ const TemplateWrapper = ({ children }) =>
     >
       <link rel="icon" href={favicon} type="image/x-icon" />
     </Helmet>
+    <CookieHeader />
     <Header />
     {children()}
     <Footer />


### PR DESCRIPTION
Note: Der Close-Button schreibt `hideCookieBanner` in localStorage. Damit "merkt" sich der Browser, dass der Nutzer das Cookie Banner nicht mehr sehen will.